### PR TITLE
Fix matching of layers with dots in the name

### DIFF
--- a/svg2mod.py
+++ b/svg2mod.py
@@ -744,11 +744,11 @@ class Svg2ModExportLegacy( Svg2ModExport ):
         'Paste' : [ 19, 18 ],
         'SilkS' : [ 21, 20 ],
         'Mask' : [ 23, 22 ],
-        'Dwgs\\.User' : [ 24, 24 ],
-        'Cmts\\.User' : [ 25, 25 ],
-        'Eco1\\.User' : [ 26, 26 ],
-        'Eco2\\.User' : [ 27, 27 ],
-        'Edge\\.Cuts' : [ 28, 28 ],
+        'Dwgs.User' : [ 24, 24 ],
+        'Cmts.User' : [ 25, 25 ],
+        'Eco1.User' : [ 26, 26 ],
+        'Eco2.User' : [ 27, 27 ],
+        'Edge.Cuts' : [ 28, 28 ],
     }
 
 


### PR DESCRIPTION
This fixes #4, turns out all the layers with dots in their name weren't getting matched. 