### PR TITLE
Switched to pretty (kicad_mod) format as default

### DIFF
--- a/svg2mod.py
+++ b/svg2mod.py
@@ -1410,7 +1410,7 @@ def get_arguments():
         metavar = 'FORMAT',
         choices = [ 'legacy', 'pretty' ],
         help = "output module file format (legacy|pretty)",
-        default = 'legacy',
+        default = 'pretty',
     )
 
     parser.add_argument(


### PR DESCRIPTION
Kasbah's suggestion https://github.com/mtl/svg2mod/issues/8 to set the new kicad_mod (pretty) format as a default output seems to make sense. This one-liner fixes that.
