### PR TITLE
Correct issues with default DPI value

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a small program to convert Inkscape SVG drawings to KiCad footprint modu
 ## Usage
 ```
 usage: svg2mod.py [-h] -i FILENAME [-o FILENAME] [--name NAME] [--value VALUE]
-                  [-f FACTOR] [-p PRECISION] [--front-only] [--format FORMAT]
+                  [-f FACTOR] [-p PRECISION] [-d DPI] [--front-only] [--format FORMAT]
                   [--units UNITS]
 
 Convert Inkscape SVG drawings to KiCad footprint modules.
@@ -24,6 +24,7 @@ optional arguments:
   -p PRECISION, --precision PRECISION
                         smoothness for approximating curves with line segments
                         (float)
+  -d DPI, --dpi DPI     DPI of the SVG file (int)
   --front-only          omit output of back module (legacy output format)
   --format FORMAT       output module file format (legacy|pretty)
   --units UNITS         output units, if output format is legacy (decimil|mm)

--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -470,8 +470,7 @@ class Svg2ModExport( object ):
 
     #------------------------------------------------------------------------
 
-    @classmethod
-    def _get_fill_stroke( cls, item ):
+    def _get_fill_stroke( self, item ):
 
         fill = True
         stroke = True
@@ -499,7 +498,7 @@ class Svg2ModExport( object ):
             stroke_width = 0.0
         elif stroke_width is None:
             # Give a default stroke width?
-            stroke_width = cls._convert_decimil_to_mm( 1 )
+            stroke_width = self._convert_decimil_to_mm( 1 )
 
         return fill, stroke, stroke_width
 

--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -12,6 +12,7 @@ import sys
 
 
 #----------------------------------------------------------------------------
+DEFAULT_DPI = 96 # 96 as of Inkscape 0.92
 
 def main():
 
@@ -61,6 +62,7 @@ def main():
             args.output_file_name,
             args.scale_factor,
             args.precision,
+            args.dpi,
         )
 
     else:
@@ -75,6 +77,7 @@ def main():
                     args.output_file_name,
                     args.scale_factor,
                     args.precision,
+                    args.dpi,
                     include_reverse = not args.front_only,
                 )
 
@@ -91,6 +94,7 @@ def main():
                 args.scale_factor,
                 args.precision,
                 use_mm = use_mm,
+                dpi = args.dpi,
                 include_reverse = not args.front_only,
             )
 
@@ -489,7 +493,7 @@ class Svg2ModExport( object ):
 
                 elif name == "stroke-width":
                     value = value.replace( "px", "" )
-                    stroke_width = float( value ) * 25.4 / 90.0
+                    stroke_width = float( value ) * 25.4 / float(self.dpi)
 
         if not stroke:
             stroke_width = 0.0
@@ -509,21 +513,22 @@ class Svg2ModExport( object ):
         scale_factor = 1.0,
         precision = 20.0,
         use_mm = True,
+        dpi = DEFAULT_DPI,
     ):
         if use_mm:
-            # 25.4 mm/in; Inkscape uses 90 DPI:
-            scale_factor *= 25.4 / 90.0
+            # 25.4 mm/in;
+            scale_factor *= 25.4 / float(dpi)
             use_mm = True
         else:
-            # PCBNew uses "decimil" (10K DPI); Inkscape uses 90 DPI:
-            scale_factor *= 10000.0 / 90.0
+            # PCBNew uses "decimil" (10K DPI);
+            scale_factor *= 10000.0 / float(dpi)
 
         self.imported = svg2mod_import
         self.file_name = file_name
         self.scale_factor = scale_factor
         self.precision = precision
         self.use_mm = use_mm
-
+        self.dpi = dpi
 
     #------------------------------------------------------------------------
 
@@ -761,6 +766,7 @@ class Svg2ModExportLegacy( Svg2ModExport ):
         scale_factor = 1.0,
         precision = 20.0,
         use_mm = True,
+        dpi = DEFAULT_DPI,
         include_reverse = True,
     ):
         super( Svg2ModExportLegacy, self ).__init__(
@@ -769,6 +775,7 @@ class Svg2ModExportLegacy( Svg2ModExport ):
             scale_factor,
             precision,
             use_mm,
+            dpi,
         )
 
         self.include_reverse = include_reverse
@@ -949,6 +956,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
         file_name,
         scale_factor = 1.0,
         precision = 20.0,
+        dpi = DEFAULT_DPI,
         include_reverse = True,
     ):
         self.file_name = file_name
@@ -960,6 +968,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
             scale_factor,
             precision,
             use_mm,
+            dpi,
             include_reverse,
         )
 
@@ -1423,6 +1432,15 @@ def get_arguments():
         default = 'mm',
     )
 
+    parser.add_argument(
+        '-d', '--dpi',
+        type = int,
+        dest = 'dpi',
+        metavar = 'DPI',
+        help = "DPI of the SVG file (int)",
+        default = DEFAULT_DPI,
+    )    
+    
     return parser.parse_args(), parser
 
 


### PR DESCRIPTION
This PR addresses issue #17 

The default DPI setting in Inkscape has changed from 90 to 96, this results in output footprints being the wrong scale.

I've replaced hardcoded DPI values with a new constant and in addition I've implemented a new flag in the command line options for those that use non-default DPI settings.

