### PR TITLE
Clean up python3 code

### DIFF
--- a/svg2mod/svg/svg/svg.py
+++ b/svg2mod/svg/svg/svg.py
@@ -262,7 +262,7 @@ class Group(Transformable):
         self.name = ""
         if elt is not None:
             
-            for id, value in elt.attrib.iteritems():
+            for id, value in elt.attrib.items():
 
                 id = self.parse_name( id )
                 if id[ "name" ] == "label":

--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -553,7 +553,7 @@ class Svg2ModExport( object ):
         if items is None:
 
             self.layers = {}
-            for name in self.layer_map.iterkeys():
+            for name in self.layer_map.keys():
                 self.layers[ name ] = None
 
             items = self.imported.svg.items
@@ -564,7 +564,7 @@ class Svg2ModExport( object ):
             if not isinstance( item, svg.Group ):
                 continue
 
-            for name in self.layers.iterkeys():
+            for name in self.layers.keys():
                 #if re.search( name, item.name, re.I ):
                 if name == item.name:
                     print( "Found SVG layer: {}".format( item.name ) )
@@ -653,7 +653,7 @@ class Svg2ModExport( object ):
             front,
         )
 
-        for name, group in self.layers.iteritems():
+        for name, group in self.layers.items():
 
             if group is None: continue
 
@@ -1094,7 +1094,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
 
         # Write index:
         for module_name in sorted(
-            self.loaded_modules.iterkeys(),
+            self.loaded_modules.keys(),
             key = str.lower
         ):
             self.output_file.write( module_name + "\n" )
@@ -1111,7 +1111,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
             up_to = up_to.lower()
 
         for module_name in sorted(
-            self.loaded_modules.iterkeys(),
+            self.loaded_modules.keys(),
             key = str.lower
         ):
             if up_to is not None and module_name.lower() >= up_to:


### PR DESCRIPTION
dict.iteritems() is not available in python3, it has been replaced with items(),
the same replacement was made for dict.iterkeys() -> keys().
Now the code executes correctly on Python 3.7.0.