### PR TITLE
Upgrade to Python 3 and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,18 @@ Python 3
 
 ```python3 setup.py install```
 
-- OR - 
+OR you can install it using the PIP package manager:
 
 ```pip3 install git+https://github.com/zirafa/svg2mod```
+
+
+## Example
+
+```python3 svg2mod.py -i input.svg```
+
+OR for PIP
+
+```svg2mod -i input.svg```
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -7,21 +7,13 @@ Python 3
 
 ## Installation
 
-```python3 setup.py install```
-
-OR you can install it using the PIP package manager:
-
 ```pip3 install git+https://github.com/zirafa/svg2mod```
 
+Note: ```python3 setup.py install``` does not work.
 
 ## Example
 
-```python3 svg2mod.py -i input.svg```
-
-OR for PIP
-
 ```svg2mod -i input.svg```
-
 
 ## Usage
 ```

--- a/README.md
+++ b/README.md
@@ -1,6 +1,19 @@
 # svg2mod
 This is a small program to convert Inkscape SVG drawings to KiCad footprint module files.  It uses [cjlano's python SVG parser and drawing module](https://github.com/cjlano/svg) to interpret drawings and approximate curves using straight line segments.  Module files can be output in KiCad's legacy or s-expression (i.e., pretty) formats.  Horizontally mirrored modules are automatically generated for use on the back of a 2-layer PCB.
 
+## Requirements
+
+Python 3
+
+## Installation
+
+```python3 setup.py install```
+
+- OR - 
+
+```pip3 install git+https://github.com/zirafa/svg2mod```
+
+
 ## Usage
 ```
 usage: svg2mod.py [-h] -i FILENAME [-o FILENAME] [--name NAME] [--value VALUE]

--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ Note: ```python3 setup.py install``` does not work.
 
 ## Example
 
-```svg2mod -i input.svg```
+```svg2mod -i input.svg -p 1.0```
 
 ## Usage
 ```
-usage: svg2mod.py [-h] -i FILENAME [-o FILENAME] [--name NAME] [--value VALUE]
+usage: svg2mod [-h] -i FILENAME [-o FILENAME] [--name NAME] [--value VALUE]
                   [-f FACTOR] [-p PRECISION] [-d DPI] [--front-only] [--format FORMAT]
                   [--units UNITS]
 

--- a/svg2mod/svg/svg/svg.py
+++ b/svg2mod/svg/svg/svg.py
@@ -262,7 +262,7 @@ class Group(Transformable):
         self.name = ""
         if elt is not None:
             
-            for id, value in elt.attrib.iteritems():
+            for id, value in elt.attrib.items():
 
                 id = self.parse_name( id )
                 if id[ "name" ] == "label":

--- a/svg2mod/svg2mod.py
+++ b/svg2mod/svg2mod.py
@@ -553,7 +553,7 @@ class Svg2ModExport( object ):
         if items is None:
 
             self.layers = {}
-            for name in self.layer_map.iterkeys():
+            for name in self.layer_map.keys():
                 self.layers[ name ] = None
 
             items = self.imported.svg.items
@@ -564,7 +564,7 @@ class Svg2ModExport( object ):
             if not isinstance( item, svg.Group ):
                 continue
 
-            for name in self.layers.iterkeys():
+            for name in self.layers.keys():
                 #if re.search( name, item.name, re.I ):
                 if name == item.name:
                     print( "Found SVG layer: {}".format( item.name ) )
@@ -653,7 +653,7 @@ class Svg2ModExport( object ):
             front,
         )
 
-        for name, group in self.layers.iteritems():
+        for name, group in self.layers.items():
 
             if group is None: continue
 
@@ -1094,7 +1094,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
 
         # Write index:
         for module_name in sorted(
-            self.loaded_modules.iterkeys(),
+            self.loaded_modules.keys(),
             key = str.lower
         ):
             self.output_file.write( module_name + "\n" )
@@ -1111,7 +1111,7 @@ class Svg2ModExportLegacyUpdater( Svg2ModExportLegacy ):
             up_to = up_to.lower()
 
         for module_name in sorted(
-            self.loaded_modules.iterkeys(),
+            self.loaded_modules.keys(),
             key = str.lower
         ):
             if up_to is not None and module_name.lower() >= up_to:


### PR DESCRIPTION
Currently svg2mod only works with Python2 and can only be installed with pip2. However the documentation does not specify which version of Python and the README installation instructions no longer work. This is causing a LOT of confusion as seen in the issue queue: https://github.com/mtl/svg2mod/issues/23#issuecomment-387824146 #24 #28 #29 #34 

It seems most new users are assuming this project should work with Python3, which it cannot -- here is a PR that both updates the relevant documentation and installation instructions, as well as code needed to get things working in Python3.

Note: The pip3 installation instructions only work with my branch atm. After merging it will need to be updated from ```pip3 install git+https://github.com/zirafa/svg2mod``` to ```pip3 install git+https://github.com/svg2mod```


